### PR TITLE
fix: external dependency version can be `null`

### DIFF
--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -94,7 +94,7 @@ class PathReference extends DependencyReference {
 }
 
 class HostedReference extends DependencyReference {
-  final VersionConstraint versionConstraint;
+  final VersionConstraint? versionConstraint;
 
   const HostedReference(this.versionConstraint);
 
@@ -111,7 +111,7 @@ class HostedReference extends DependencyReference {
 
 class ExternalHostedReference extends DependencyReference {
   final String? name, url;
-  final VersionConstraint versionConstraint;
+  final VersionConstraint? versionConstraint;
   final bool verboseFormat;
 
   ExternalHostedReference(this.name, this.url, this.versionConstraint,
@@ -119,26 +119,33 @@ class ExternalHostedReference extends DependencyReference {
 
   ExternalHostedReference.fromJson(Map json)
       : this(
-            json['hosted'] is String ? null : json['hosted']['name'],
-            json['hosted'] is String ? json['hosted'] : json['hosted']['url'],
-            VersionConstraint.parse(json['version']),
-            json['hosted'] is String ? false : true);
+      json['hosted'] is String ? null : json['hosted']['name'],
+      json['hosted'] is String ? json['hosted'] : json['hosted']['url'],
+      json['version'] != null
+          ? VersionConstraint.parse(json['version'])
+          : null,
+      json['hosted'] is String ? false : true);
 
   bool operator ==(other) =>
       other is ExternalHostedReference &&
-      other.name == name &&
-      other.url == url &&
-      other.versionConstraint == versionConstraint;
+          other.name == name &&
+          other.url == url &&
+          other.versionConstraint == versionConstraint;
 
   @override
   toJson() {
     if (verboseFormat) {
       return {
         'hosted': {'name': name, 'url': url},
-        'version': versionConstraint.toString()
+        'version':
+        versionConstraint != null ? versionConstraint.toString() : null
       };
     } else {
-      return {'hosted': url, 'version': versionConstraint.toString()};
+      return {
+        'hosted': url,
+        'version':
+        versionConstraint != null ? versionConstraint.toString() : null
+      };
     }
   }
 }

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -64,6 +64,15 @@ main() {
       expect(json['hosted']['name'], 'custom_lib');
       expect(json['version'], '^0.1.0');
     });
+
+    test('to json with a `null` version', () {
+      var exDep = ExternalHostedReference(
+          'custom_lib', 'https://pub.mycompany.org', null);
+      var json = exDep.toJson();
+      expect(json['hosted']['url'], 'https://pub.mycompany.org');
+      expect(json['hosted']['name'], 'custom_lib');
+      expect(json['version'], null);
+    });
   });
 
   /// According to https://www.dartlang.org/tools/pub/dependencies#version-constraints:


### PR DESCRIPTION
This PR allows external dependencies to have a nullable version constraint. Otherwise, an exception is thrown. For example, add this to your app `pubspec.yaml` and you will see an exception:

```yaml
dependencies:
  xetia_core:
    hosted:
      name: xetia_core
      url: https://pub.xetia.dev
    version:
```